### PR TITLE
Initial interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.3 | ^7.0"
+        "php": "^5.3 | ^7.0",
+        "psr/container": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
         "phpunit/phpunit": "^4.8",
         "ptrofimov/xpmock": "^1.1",
         "dhii/php-cs-fixer-config": "dev-php-5.3",
-        "codeclimate/php-test-reporter": "<=0.3.2"
+        "codeclimate/php-test-reporter": "<=0.3.2",
+        "dhii/stringable-interface": "^0.1"
+    },
+    "suggest": {
+        "dhii/stringable-interface": "To be able to pass Stringables as keys"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Dhii\\Data\\": "src"
+            "Dhii\\Data\\Container\\": "src"
         }
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "345286589a536f30ab3b1deb9e33ab0e",
+    "content-hash": "82bbbe939aacf335ca574c7b210dd241",
     "packages": [
         {
             "name": "psr/container",
@@ -154,6 +154,48 @@
             ],
             "description": "A default PHP CS Fixer config implementation",
             "time": "2016-09-03 14:45:03"
+        },
+        {
+            "name": "dhii/stringable-interface",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/stringable-interface.git",
+                "reference": "b6653905eef2ebf377749feb80a6d18abbe913ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/stringable-interface/zipball/b6653905eef2ebf377749feb80a6d18abbe913ef",
+                "reference": "b6653905eef2ebf377749feb80a6d18abbe913ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Util\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Interoperability interface for objects that can be cast to string",
+            "time": "2017-01-23T15:08:20+00:00"
         },
         {
             "name": "doctrine/instantiator",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,58 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "04f74769c5f7d50920232deb581f6028",
-    "packages": [],
+    "content-hash": "345286589a536f30ab3b1deb9e33ab0e",
+    "packages": [
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "codeclimate/php-test-reporter",

--- a/src/ContainerAwareInterface.php
+++ b/src/ContainerAwareInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Dhii\Data\Container;
+
+/**
+ * Something that can have a container retrieved.
+ *
+ * @since [*next-version*]
+ */
+interface ContainerAwareInterface
+{
+    /**
+     * Retrieves the container associated with this instance.
+     *
+     * @since [*next-version*]
+     *
+     * @return ContainerInterface The container.
+     */
+    public function getContainer();
+}

--- a/src/ContainerAwareInterface.php
+++ b/src/ContainerAwareInterface.php
@@ -14,7 +14,7 @@ interface ContainerAwareInterface
      *
      * @since [*next-version*]
      *
-     * @return ContainerInterface The container.
+     * @return ContainerInterface|null The container, if any.
      */
     public function getContainer();
 }

--- a/src/ContainerInterface.php
+++ b/src/ContainerInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Dhii\Data\Container;
+
+use Psr\Container\ContainerInterface as BaseContainerInterface;
+use Dhii\Util\String\StringableInterface as Stringable;
+use Dhii\Data\Container\Exception\NotFoundExceptionInterface;
+use Dhii\Data\Container\Exception\ContainerExceptionInterface;
+
+/**
+ * Represents something that can have data retrieved by key.
+ *
+ * @since [*next-version*]
+ */
+interface ContainerInterface extends
+        HasCapableInterface,
+        BaseContainerInterface
+{
+    /**
+     * Retrieves something that corresponds to the key.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|Stringable $key The key to retrieve the data for.
+     *
+     * @throws NotFoundExceptionInterface  If data for key is not found.
+     * @throws ContainerExceptionInterface If a problem occurs while retrieving.
+     */
+    public function get($key);
+}

--- a/src/Exception/ContainerExceptionInterface.php
+++ b/src/Exception/ContainerExceptionInterface.php
@@ -3,12 +3,15 @@
 namespace Dhii\Data\Container\Exception;
 
 use Dhii\Data\Container\ContainerAwareInterface;
+use Psr\Container\ContainerExceptionInterface as BaseContainerExceptionInterface;
 
 /**
  * An exception that occurs in relation to a container.
  *
  * @since [*next-version*]
  */
-interface ContainerExceptionInterface extends ContainerAwareInterface
+interface ContainerExceptionInterface extends
+        ContainerAwareInterface,
+        BaseContainerExceptionInterface
 {
 }

--- a/src/Exception/ContainerExceptionInterface.php
+++ b/src/Exception/ContainerExceptionInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Dhii\Data\Container\Exception;
+
+use Dhii\Data\Container\ContainerAwareInterface;
+
+/**
+ * An exception that occurs in relation to a container.
+ *
+ * @since [*next-version*]
+ */
+interface ContainerExceptionInterface extends ContainerAwareInterface
+{
+}

--- a/src/Exception/NotFoundExceptionInterface.php
+++ b/src/Exception/NotFoundExceptionInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Dhii\Data\Container\Exception;
+
+use Psr\Container\NotFoundExceptionInterface as BaseNotFoundExceptionInterface;
+
+/**
+ * Represents an exception which occurs when data requested for a key is not found.
+ *
+ * @since [*next-version*]
+ */
+interface NotFoundExceptionInterface extends
+        BaseNotFoundExceptionInterface,
+        ContainerExceptionInterface
+{
+    /**
+     * Retrieves the associated key.
+     *
+     * @since [*next-version*]
+     *
+     * @return string The key, for which data was requested.
+     */
+    public function getDataKey();
+}

--- a/src/Exception/NotFoundExceptionInterface.php
+++ b/src/Exception/NotFoundExceptionInterface.php
@@ -18,7 +18,7 @@ interface NotFoundExceptionInterface extends
      *
      * @since [*next-version*]
      *
-     * @return string The key, for which data was requested.
+     * @return string The key, for which data was requested, if any.
      */
     public function getDataKey();
 }

--- a/src/HasCapableInterface.php
+++ b/src/HasCapableInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Dhii\Data\Container;
+
+use Dhii\Util\String\StringableInterface as Stringable;
+use Dhii\Data\Container\Exception\ContainerExceptionInterface;
+
+/**
+ * Represents something that can have data checked for by key.
+ *
+ * @since [*next-version*]
+ */
+interface HasCapableInterface
+{
+    /**
+     * Checks whether this instance has data for a key.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|Stringable $key The key to check for.
+     *
+     * @throws ContainerExceptionInterface If a problem occurs while checking.
+     *
+     * @return bool True if data exists for the key; otherwise false.
+     */
+    public function has($key);
+}

--- a/test/unit/ContainerAwareInterfaceTest.php
+++ b/test/unit/ContainerAwareInterfaceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Dhii\Data\Container\UnitTest;
+
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \Dhii\Data\Container\ContainerAwareInterface}.
+ *
+ * @since [*next-version*]
+ */
+class ContainerAwareInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Data\\Container\\ContainerAwareInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \Dhii\Data\Container\ContainerAwareInterface The new instance.
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(self::TEST_SUBJECT_CLASSNAME)
+                ->getContainer()
+                ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a correct instance of a descendant can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
+    }
+}

--- a/test/unit/ContainerInterfaceTest.php
+++ b/test/unit/ContainerInterfaceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Dhii\Data\Container\UnitTest;
+
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \Dhii\Data\Container\ContainerInterface}.
+ *
+ * @since [*next-version*]
+ */
+class ContainerInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Data\\Container\\ContainerInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \Dhii\Data\Container\ContainerInterface The new instance.
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(self::TEST_SUBJECT_CLASSNAME)
+                ->get()
+                ->has()
+                ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a correct instance of a descendant can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
+        $this->assertInstanceOf('Dhii\\Data\\Container\\HasCapableInterface', $subject, 'Subject does not implement required interface');
+    }
+}

--- a/test/unit/Exception/ContainerExceptionInterfaceTest.php
+++ b/test/unit/Exception/ContainerExceptionInterfaceTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Dhii\Data\Container\Exception\UnitTest;
+
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \Dhii\Data\Container\Exception\ContainerExceptionInterface}.
+ *
+ * @since [*next-version*]
+ */
+class ContainerExceptionInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Data\\Container\\Exception\\ContainerExceptionInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \Dhii\Data\Container\Exception\ContainerExceptionInterface The new instance.
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(self::TEST_SUBJECT_CLASSNAME)
+                ->getContainer()
+                ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a correct instance of a descendant can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
+        $this->assertInstanceOf('Dhii\\Data\\Container\\ContainerAwareInterface', $subject, 'Subject does not implement required interface');
+    }
+}

--- a/test/unit/Exception/ContainerExceptionInterfaceTest.php
+++ b/test/unit/Exception/ContainerExceptionInterfaceTest.php
@@ -45,5 +45,6 @@ class ContainerExceptionInterfaceTest extends TestCase
 
         $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
         $this->assertInstanceOf('Dhii\\Data\\Container\\ContainerAwareInterface', $subject, 'Subject does not implement required interface');
+        $this->assertInstanceOf('Psr\\Container\\ContainerExceptionInterface', $subject, 'Subject does not implement required interface');
     }
 }

--- a/test/unit/Exception/NotFoundExceptionInterfaceTest.php
+++ b/test/unit/Exception/NotFoundExceptionInterfaceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Dhii\Data\Container\Exception\UnitTest;
+
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \Dhii\Data\Container\Exception\NotFoundExceptionInterface}.
+ *
+ * @since [*next-version*]
+ */
+class NotFoundExceptionInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Data\\Container\\Exception\\NotFoundExceptionInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \Dhii\Data\Container\Exception\NotFoundExceptionInterface The new instance.
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(self::TEST_SUBJECT_CLASSNAME)
+                ->getContainer()
+                ->getDataKey()
+                ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a correct instance of a descendant can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
+        $this->assertInstanceOf('Dhii\\Data\\Container\\ContainerAwareInterface', $subject, 'Subject does not implement required interface');
+    }
+}

--- a/test/unit/Exception/NotFoundExceptionInterfaceTest.php
+++ b/test/unit/Exception/NotFoundExceptionInterfaceTest.php
@@ -45,6 +45,6 @@ class NotFoundExceptionInterfaceTest extends TestCase
         $subject = $this->createInstance();
 
         $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
-        $this->assertInstanceOf('Dhii\\Data\\Container\\ContainerAwareInterface', $subject, 'Subject does not implement required interface');
+        $this->assertInstanceOf('Dhii\\Data\\Container\\Exception\\ContainerExceptionInterface', $subject, 'Subject does not implement required interface');
     }
 }

--- a/test/unit/HasCapableInterfaceTest.php
+++ b/test/unit/HasCapableInterfaceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Dhii\Data\Container\UnitTest;
+
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \Dhii\Data\Container\HasCapableInterface}.
+ *
+ * @since [*next-version*]
+ */
+class HasCapableInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Data\\Container\\HasCapableInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \Dhii\Data\Container\HasCapableInterface The new instance.
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(self::TEST_SUBJECT_CLASSNAME)
+                ->has()
+                ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a correct instance of a descendant can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
+    }
+}


### PR DESCRIPTION
Added interfaces and tests.

This package extends PSR-11, and enhances it in the following ways:
1. There's now a separate interface for `has()`, `HasCapableInterface`, which is extended by `ContainerInterface`; this promotes interface segregation.
2. There's now a new interface `ContainerAwareInterface`. `ContainerExceptionInterface` now extends it.
3. `NotFoundExceptionInterface` is now also container-aware, and data-key-aware.
4. Exceptions have their own namespace.