### PR TITLE
Add set-capable container and more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,14 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
+  - '7.3'
   - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
+  fast_finish: true
 
 before_script:
   - composer update --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   fast_finish: true
 
 before_script:
+  - phpenv config-add travis.php.ini
   - composer update --prefer-dist
 script:
   - vendor/bin/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Added
+- `SetCapableContainerInterface`;
+- `DeleteCapableContainerInterface`.
+- `ClearCapableContainerInterface`.
 
 ## [0.2-alpha3] - 2018-04-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ is no dependency on that package; implementations are responsible for requiring
 - [`ContainerInterface`] - Allows checking for and retrieval of data value by key.
 - [`ContainerAwareInterface`] - Allows retrieval of a container instance.
 - [`SetCapableInterface`] - Allows setting the value for a key.
+- [`SetCapableContainerInterface`] - A container that can have a value set for a key.
 - [`DeleteCapableInterface`] - Allows deleting a value by key.
+- [`DeleteCapableContainerInterface`] - A container that allows deleting a value by key.
 - [`ClearCapableInterface`] - Allows deleting all values.
+- [`ClearCapableContainerInterface`] - A container that allows deleting all values.
 - [`ContainerFactoryInterface`] - A factory that can create containers.
 - [`ContainerExceptionInterface`] - An exception that occurs in relation to a container,
 and is aware of that container.
@@ -64,8 +67,11 @@ retrieve data for key that is not set, and is also container aware by extension.
 [`ContainerInterface`]:               ./src/ContainerInterface.php
 [`ContainerAwareInterface`]:          ./src/ContainerAwareInterface.php
 [`SetCapableInterface`]:              ./src/SetCapableInterface.php
+[`SetCapableContainerInterface`]:     ./src/SetCapableContainerInterface.php
 [`DeleteCapableInterface`]:           ./src/DeleteCapableInterface.php
+[`DeleteCapableContainerInterface`]:  ./src/DeleteCapableContainerInterface.php
 [`ClearCapableInterface`]:            ./src/ClearCapableInterface.php
+[`ClearCapableContainerInterface`]:   ./src/ClearCapableContainerInterface.php
 [`ContainerFactoryInterface`]:        ./src/ContainerFactoryInterface.php
 [`ContainerExceptionInterface`]:      ./src/Exception/ContainerExceptionInterface.php
 [`NotFoundExceptionInterface`]:       ./src/Exception/NotFoundExceptionInterface.php

--- a/src/ClearCapableContainerInterface.php
+++ b/src/ClearCapableContainerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Dhii\Data\Container;
+
+use Psr\Container\ContainerInterface as BaseContainerInterface;
+
+/**
+ * A container that can have its members cleared
+ *
+ * @since [*next-version*]
+ */
+interface ClearCapableContainerInterface extends
+    BaseContainerInterface,
+    ClearCapableInterface
+{
+}

--- a/src/DeleteCapableContainerInterface.php
+++ b/src/DeleteCapableContainerInterface.php
@@ -7,7 +7,7 @@ use Psr\Container\ContainerInterface as BaseContainerInterface;
 use Psr\Container\ContainerExceptionInterface;
 
 /**
- * Exposes means of deleting a data member.
+ * A container that can have a member removed.
  *
  * @since [*next-version*]
  */

--- a/src/DeleteCapableContainerInterface.php
+++ b/src/DeleteCapableContainerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Dhii\Data\Container;
+
+use Dhii\Util\String\StringableInterface as Stringable;
+use Psr\Container\ContainerInterface as BaseContainerInterface;
+use Psr\Container\ContainerExceptionInterface;
+
+/**
+ * Exposes means of deleting a data member.
+ *
+ * @since [*next-version*]
+ */
+interface DeleteCapableContainerInterface extends
+    BaseContainerInterface,
+    DeleteCapableInterface
+{
+    /**
+     * Removes a data member from the object by key.
+     *
+     * @since [*next-version*]
+     *
+     * @param string|int|float|bool|Stringable $key The key of the data member to delete.
+     *
+     * @throws ContainerExceptionInterface If data member could not be deleted.
+     */
+    public function delete($key);
+}

--- a/src/SetCapableContainerInterface.php
+++ b/src/SetCapableContainerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Dhii\Data\Container;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * A container that can have values set.
+ */
+interface SetCapableContainerInterface extends
+    ContainerInterface,
+    SetCapableInterface
+{
+}

--- a/src/SetCapableContainerInterface.php
+++ b/src/SetCapableContainerInterface.php
@@ -2,13 +2,13 @@
 
 namespace Dhii\Data\Container;
 
-use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerInterface as BaseContainerInterface;
 
 /**
  * A container that can have values set.
  */
 interface SetCapableContainerInterface extends
-    ContainerInterface,
+    BaseContainerInterface,
     SetCapableInterface
 {
 }

--- a/src/WritableContainerInterface.php
+++ b/src/WritableContainerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Dhii\Data\Container;
+
+/**
+ * Represents a container with complete read and write access to individual elements.
+ *
+ * @package Dhii\Data\Container
+ */
+interface WritableContainerInterface extends
+    SetCapableContainerInterface,
+    DeleteCapableContainerInterface
+{
+}

--- a/test/unit/ClearCapableContainerInterfaceTest.php
+++ b/test/unit/ClearCapableContainerInterfaceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Dhii\Data\Container\UnitTest;
+
+use Xpmock\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Dhii\Data\Container\ClearCapableContainerInterface as TestSubject;
+
+/**
+ * Tests {@see TestSubject}.
+ *
+ * @since [*next-version*]
+ */
+class ClearCapableContainerInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\Data\Container\ClearCapableContainerInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return TestSubject|MockObject The new instance.
+     */
+    public function createInstance()
+    {
+        $mock = $this->getMockBuilder(self::TEST_SUBJECT_CLASSNAME)
+                ->getMock();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a correct instance of a descendant can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
+        $this->assertInstanceOf('Dhii\Data\Container\ClearCapableInterface', $subject, 'Subject does not implement required interface');
+        $this->assertInstanceOf('Psr\Container\ContainerInterface', $subject, 'Subject does not implement required interface');
+    }
+}

--- a/test/unit/DeleteCapableContainerInterfaceTest.php
+++ b/test/unit/DeleteCapableContainerInterfaceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Dhii\Data\Container\UnitTest;
+
+use Xpmock\TestCase;
+use Dhii\Data\Container\DeleteCapableContainerInterface as TestSubject;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * Tests {@see TestSubject}.
+ *
+ * @since [*next-version*]
+ */
+class DeleteCapableContainerInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\Data\Container\DeleteCapableContainerInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return TestSubject|MockObject The new instance.
+     */
+    public function createInstance()
+    {
+        $mock = $this->getMockBuilder(self::TEST_SUBJECT_CLASSNAME)
+                ->getMock();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a correct instance of a descendant can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
+        $this->assertInstanceOf('Dhii\Data\Container\DeleteCapableInterface', $subject, 'Subject does not implement required interface');
+        $this->assertInstanceOf('Psr\Container\ContainerInterface', $subject, 'Subject does not implement required interface');
+    }
+}

--- a/test/unit/SetCapableContainerInterfaceTest.php
+++ b/test/unit/SetCapableContainerInterfaceTest.php
@@ -45,7 +45,7 @@ class SetCapableContainerInterfaceTest extends TestCase
         $subject = $this->createInstance();
 
         $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
-        $this->assertInstanceOf('Dhii\Data\Container\ContainerInterface', $subject, 'Subject does not implement required interface');
+        $this->assertInstanceOf('Psr\Container\ContainerInterface', $subject, 'Subject does not implement required interface');
         $this->assertInstanceOf('Dhii\Data\Container\SetCapableInterface', $subject, 'Subject does not implement required interface');
     }
 }

--- a/test/unit/SetCapableContainerInterfaceTest.php
+++ b/test/unit/SetCapableContainerInterfaceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Dhii\Data\Container\UnitTest;
+
+use Xpmock\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Dhii\Data\Container\SetCapableContainerInterface as TestSubject;
+
+/**
+ * Tests {@see TestSubject}.
+ *
+ * @since [*next-version*]
+ */
+class SetCapableInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\Data\Container\SetCapableContainerInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return TestSubject|MockObject The new instance.
+     */
+    public function createInstance()
+    {
+        $mock = $this->getMockBuilder(self::TEST_SUBJECT_CLASSNAME)
+            ->getMock();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a correct instance of a descendant can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
+        $this->assertInstanceOf('Dhii\Data\Container\ContainerInterface', $subject, 'Subject does not implement required interface');
+        $this->assertInstanceOf('Dhii\Data\Container\SetCapableInterface', $subject, 'Subject does not implement required interface');
+    }
+}

--- a/test/unit/SetCapableContainerInterfaceTest.php
+++ b/test/unit/SetCapableContainerInterfaceTest.php
@@ -11,7 +11,7 @@ use Dhii\Data\Container\SetCapableContainerInterface as TestSubject;
  *
  * @since [*next-version*]
  */
-class SetCapableInterfaceTest extends TestCase
+class SetCapableContainerInterfaceTest extends TestCase
 {
     /**
      * The name of the test subject.

--- a/test/unit/WritableContainerInterfaceTest.php
+++ b/test/unit/WritableContainerInterfaceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Dhii\Data\Container\UnitTest;
+
+use Xpmock\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Dhii\Data\Container\WritableContainerInterface as TestSubject;
+
+/**
+ * Tests {@see TestSubject}.
+ *
+ * @since 0.1
+ */
+class WritableContainerInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since 0.1
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\Data\Container\WritableContainerInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since 0.1
+     *
+     * @return TestSubject|MockObject The new instance.
+     */
+    public function createInstance()
+    {
+        $mock = $this->getMockBuilder(self::TEST_SUBJECT_CLASSNAME)
+            ->setMethods(array('get', 'has', 'set', 'delete'))
+            ->getMock();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a correct instance of a descendant can be created.
+     *
+     * @since 0.1
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(self::TEST_SUBJECT_CLASSNAME, $subject, 'A correct instance of the test subject could not be created');
+        $this->assertInstanceOf('Dhii\Data\Container\SetCapableContainerInterface', $subject, 'Subject does not implement required interface');
+        $this->assertInstanceOf('Dhii\Data\Container\DeleteCapableContainerInterface', $subject, 'Subject does not implement required interface');
+    }
+}

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = 1024M

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,1 +1,1 @@
-memory_limit = 1024M
+memory_limit = 2048M


### PR DESCRIPTION
- Also, clear-capable and delete-capable containers added.
- PHP nightly build now allowed to fail.
- Fixed issue with PHP 5.3 build failing due to memory limit during Composer update.